### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # temp-email
-Genearting a temporary email
+Generating a temporary email


### PR DESCRIPTION
## Summary
- fix a typo in the README header

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684481ec371c83328605458a9a06c8fe