### PR TITLE
Add domain selection dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ A simple static page to generate and read disposable emails using the [1secmail]
 
 ## How it works
 
-`index.html` creates a unique mailbox when you click **Generate New Email**. The address is displayed on the page and the **Check for Messages** button becomes active. Clicking it fetches messages for that inbox from the API. Selecting a message loads its contents and highlights sequences of 4–8 digits (useful for OTP codes).
+`index.html` creates a unique mailbox when you click **Generate New Email**. The address is displayed on the page and the **Check for Messages** button becomes active. Use the domain dropdown to choose `1secmail.com`, `1secmail.org` or `1secmail.net` before generating. Clicking **Check for Messages** fetches messages for that inbox from the API. Selecting a message loads its contents and highlights sequences of 4–8 digits (useful for OTP codes).
 
 ## Prerequisites
 
 - A modern web browser
-- An active internet connection (API requests are made to `1secmail.com`)
+- An active internet connection (API requests use the selected 1secmail domain)
 - The page loads [DOMPurify](https://github.com/cure53/DOMPurify) from a CDN for sanitizing email content
 
 ## Run locally

--- a/index.html
+++ b/index.html
@@ -28,6 +28,11 @@
             font-size: 16px;
         }
         button:hover { background-color: #45a049; }
+        select {
+            padding: 10px;
+            font-size: 16px;
+            margin-left: 5px;
+        }
         .highlight { background-color: #ffeb3b; padding: 2px; }
     </style>
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.4/dist/purify.min.js"></script>
@@ -37,6 +42,12 @@
     <div class="container">
         <h2>Your Temporary Email</h2>
         <div id="email-display" class="email-box">No email generated yet</div>
+        <label for="domain-select">Domain:</label>
+        <select id="domain-select">
+            <option value="1secmail.com">1secmail.com</option>
+            <option value="1secmail.org">1secmail.org</option>
+            <option value="1secmail.net">1secmail.net</option>
+        </select>
         <button id="generate-btn">Generate New Email</button>
         <button id="refresh-btn" disabled>Check for Messages</button>
         <p id="status"></p>
@@ -49,9 +60,10 @@
     </div>
 
     <script>
-        let user, domain = '1secmail.com';
+        let user, domain;
 
         document.getElementById('generate-btn').onclick = () => {
+            domain = document.getElementById('domain-select').value;
             user = 'user' + Date.now();
             const email = user + '@' + domain;
             document.getElementById('email-display').textContent = email;


### PR DESCRIPTION
## Summary
- let the user select the domain via a dropdown
- reference chosen domain when generating address
- clarify domain selection usage in the README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68448693283c8332a95d6eb659fb86a1